### PR TITLE
DRAFT: Add test target to configure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "stf_lib"]
 	path = stf_lib
 	url = https://github.com/sparcians/stf_lib.git
+[submodule "cpm.riscv-tests"]
+	path = cpm.riscv-tests
+	url = git@github.com:Condor-Performance-Modeling/cpm.riscv-tests.git

--- a/Makefile.in
+++ b/Makefile.in
@@ -526,6 +526,30 @@ debug-% :
 	@echo $* = $($*)
 
 #-------------------------------------------------------------------------
+# RISCV and custom tests
+#-------------------------------------------------------------------------
+
+RISCV_TESTS_PREFIX := $(shell pwd)/$(src_dir)/tests/test_binaries
+SPIKE_BINARY := $(shell pwd)/spike
+
+.PHONY: build-riscv-tests
+build-riscv-tests:
+	@echo "Running autoconf..."
+	@cd $(src_dir)/cpm.riscv-tests && autoconf
+	@echo "Running ./configure with --prefix=$(RISCV_TESTS_PREFIX)..."
+	@cd $(src_dir)/cpm.riscv-tests && ./configure --prefix=$(RISCV_TESTS_PREFIX) --disable-custom-stf-load-store
+	@echo "Building riscv-tests..."
+	@cd $(src_dir)/cpm.riscv-tests && make
+	@echo "Installing riscv-tests to $(RISCV_TESTS_PREFIX)..."
+	@cd $(src_dir)/cpm.riscv-tests && make install
+	@echo "riscv-tests build and installation complete!"
+
+.PHONY: test
+test: all build-riscv-tests
+	@echo "Running tests in the tests directory with SPIKE_BINARY=$(SPIKE_BINARY)..."
+	@make -C $(src_dir)/tests SPIKE_BINARY=$(SPIKE_BINARY)
+
+#-------------------------------------------------------------------------
 # Clean up junk
 #-------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ install path.
 If your system uses the `yum` package manager, you can substitute
 `yum install dtc` for the first step.
 
+Test Steps
+---------------
+
+We assume that the RISCV environment variable is set to the RISC-V tools
+install path.
+
+> [!IMPORTANT]  
+> To build `riscv-tests` submodule that generates test binaries, `riscv64-unknown-elf-gcc` must be added to your PATH.
+
+    $ apt-get install device-tree-compiler libboost-regex-dev libboost-system-dev
+    $ mkdir build
+    $ cd build
+    $ ../configure --prefix=$RISCV
+    $ make test
+
+If your system uses the `yum` package manager, you can substitute
+`yum install dtc` for the first step.
+
 Build Steps on OpenBSD
 ----------------------
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,21 @@
+TEST_SCRIPTS := $(wildcard scripts/*.sh)
+TEST_TARGETS := $(patsubst scripts/%,run-%, $(TEST_SCRIPTS))
+
+.PHONY: all
+all: $(TEST_TARGETS)
+	@echo "All tests complete!"
+
+$(TEST_TARGETS): run-%: scripts/%
+	@echo "Running $< with SPIKE_BINARY=$(SPIKE_BINARY)..."
+	@if SPIKE_BINARY=$(SPIKE_BINARY) bash $<; then \
+		echo "Test $< PASSED!"; \
+	else \
+		echo "Test $< FAILED!"; \
+	fi
+
+.PHONY: list
+list:
+	@echo "Available test scripts:"
+	@for script in $(TEST_SCRIPTS); do \
+		echo "  $$script"; \
+	done

--- a/tests/scripts/isa_test_list.txt
+++ b/tests/scripts/isa_test_list.txt
@@ -1,0 +1,673 @@
+# ===================================================================
+# NOTE: this file is generated, comments/ordering are not preserved
+# when running update_isa_tests_list.sh.
+# ===================================================================
+
+# -------------------------------------------------------------------
+# Passing M (all RV64)
+# -------------------------------------------------------------------
+rv64um-p-div
+rv64um-p-divu
+rv64um-p-divuw
+rv64um-p-divw
+rv64um-p-mul
+rv64um-p-mulh
+rv64um-p-mulhsu
+rv64um-p-mulhu
+rv64um-p-mulw
+rv64um-p-rem
+rv64um-p-remu
+rv64um-p-remuw
+rv64um-p-remw
+rv64um-v-div
+rv64um-v-divu
+rv64um-v-divuw
+rv64um-v-divw
+rv64um-v-mul
+rv64um-v-mulh
+rv64um-v-mulhsu
+rv64um-v-mulhu
+rv64um-v-mulw
+rv64um-v-rem
+rv64um-v-remu
+rv64um-v-remuw
+rv64um-v-remw
+
+# -------------------------------------------------------------------
+# Passing mI (all RV64)
+# -------------------------------------------------------------------
+rv64mi-p-access
+rv64mi-p-breakpoint
+rv64mi-p-csr
+rv64mi-p-illegal
+rv64mi-p-ld-misaligned
+rv64mi-p-lh-misaligned
+rv64mi-p-lw-misaligned
+rv64mi-p-ma_addr
+rv64mi-p-ma_fetch
+rv64mi-p-mcsr
+rv64mi-p-sbreak
+rv64mi-p-scall
+rv64mi-p-sd-misaligned
+rv64mi-p-sh-misaligned
+rv64mi-p-sw-misaligned
+rv64mi-p-zicntr
+# -------------------------------------------------------------------
+# Passing sI (all RV64)
+# -------------------------------------------------------------------
+rv64si-p-csr
+rv64si-p-dirty
+rv64si-p-icache-alias
+rv64si-p-ma_fetch
+rv64si-p-sbreak
+rv64si-p-scall
+rv64si-p-wfi
+# -------------------------------------------------------------------
+# Passing uA (all RV64)
+# -------------------------------------------------------------------
+rv64ua-p-amoadd_d
+rv64ua-p-amoadd_w
+rv64ua-p-amoand_d
+rv64ua-p-amoand_w
+rv64ua-p-amomax_d
+rv64ua-p-amomax_w
+rv64ua-p-amomaxu_d
+rv64ua-p-amomaxu_w
+rv64ua-p-amomin_d
+rv64ua-p-amomin_w
+rv64ua-p-amominu_d
+rv64ua-p-amominu_w
+rv64ua-p-amoor_d
+rv64ua-p-amoor_w
+rv64ua-p-amoswap_d
+rv64ua-p-amoswap_w
+rv64ua-p-amoxor_d
+rv64ua-p-amoxor_w
+rv64ua-p-lrsc
+rv64ua-v-amoadd_d
+rv64ua-v-amoadd_w
+rv64ua-v-amoand_d
+rv64ua-v-amoand_w
+rv64ua-v-amomax_d
+rv64ua-v-amomax_w
+rv64ua-v-amomaxu_d
+rv64ua-v-amomaxu_w
+rv64ua-v-amomin_d
+rv64ua-v-amomin_w
+rv64ua-v-amominu_d
+rv64ua-v-amominu_w
+rv64ua-v-amoor_d
+rv64ua-v-amoor_w
+rv64ua-v-amoswap_d
+rv64ua-v-amoswap_w
+rv64ua-v-amoxor_d
+rv64ua-v-amoxor_w
+rv64ua-v-lrsc
+# -------------------------------------------------------------------
+# Passing uC (all RV64)
+# -------------------------------------------------------------------
+rv64uc-p-rvc
+rv64uc-v-rvc
+# -------------------------------------------------------------------
+# Passing D (all RV64)
+# -------------------------------------------------------------------
+rv64ud-p-fadd
+rv64ud-p-fclass
+rv64ud-p-fcmp
+rv64ud-p-fcvt
+rv64ud-p-fcvt_w
+rv64ud-p-fdiv
+rv64ud-p-fmadd
+rv64ud-p-fmin
+rv64ud-p-ldst
+rv64ud-p-move
+rv64ud-p-recoding
+rv64ud-p-structural
+rv64ud-v-fadd
+rv64ud-v-fclass
+rv64ud-v-fcmp
+rv64ud-v-fcvt
+rv64ud-v-fcvt_w
+rv64ud-v-fdiv
+rv64ud-v-fmadd
+rv64ud-v-fmin
+rv64ud-v-ldst
+rv64ud-v-move
+rv64ud-v-recoding
+rv64ud-v-structural
+# -------------------------------------------------------------------
+# Passing F (all RV64)
+# -------------------------------------------------------------------
+rv64uf-p-fadd
+rv64uf-p-fclass
+rv64uf-p-fcmp
+rv64uf-p-fcvt
+rv64uf-p-fcvt_w
+rv64uf-p-fdiv
+rv64uf-p-fmadd
+rv64uf-p-fmin
+rv64uf-p-ldst
+rv64uf-p-move
+rv64uf-p-recoding
+rv64uf-v-fadd
+rv64uf-v-fclass
+rv64uf-v-fcmp
+rv64uf-v-fcvt
+rv64uf-v-fcvt_w
+rv64uf-v-fdiv
+rv64uf-v-fmadd
+rv64uf-v-fmin
+rv64uf-v-ldst
+rv64uf-v-move
+rv64uf-v-recoding
+# -------------------------------------------------------------------
+# Passing I (all RV64)
+# -------------------------------------------------------------------
+rv64ui-p-add
+rv64ui-p-addi
+rv64ui-p-addiw
+rv64ui-p-addw
+rv64ui-p-and
+rv64ui-p-andi
+rv64ui-p-auipc
+rv64ui-p-beq
+rv64ui-p-bge
+rv64ui-p-bgeu
+rv64ui-p-blt
+rv64ui-p-bltu
+rv64ui-p-bne
+rv64ui-p-fence_i
+rv64ui-p-jal
+rv64ui-p-jalr
+rv64ui-p-lb
+rv64ui-p-lbu
+rv64ui-p-ld
+rv64ui-p-lh
+rv64ui-p-lhu
+rv64ui-p-lui
+rv64ui-p-lw
+rv64ui-p-lwu
+rv64ui-p-or
+rv64ui-p-ori
+rv64ui-p-sb
+rv64ui-p-sd
+rv64ui-p-sh
+rv64ui-p-simple
+rv64ui-p-sll
+rv64ui-p-slli
+rv64ui-p-slliw
+rv64ui-p-sllw
+rv64ui-p-slt
+rv64ui-p-slti
+rv64ui-p-sltiu
+rv64ui-p-sltu
+rv64ui-p-sra
+rv64ui-p-srai
+rv64ui-p-sraiw
+rv64ui-p-sraw
+rv64ui-p-srl
+rv64ui-p-srli
+rv64ui-p-srliw
+rv64ui-p-srlw
+rv64ui-p-sub
+rv64ui-p-subw
+rv64ui-p-sw
+rv64ui-p-xor
+rv64ui-p-xori
+rv64ui-v-add
+rv64ui-v-addi
+rv64ui-v-addiw
+rv64ui-v-addw
+rv64ui-v-and
+rv64ui-v-andi
+rv64ui-v-auipc
+rv64ui-v-beq
+rv64ui-v-bge
+rv64ui-v-bgeu
+rv64ui-v-blt
+rv64ui-v-bltu
+rv64ui-v-bne
+rv64ui-v-fence_i
+rv64ui-v-jal
+rv64ui-v-jalr
+rv64ui-v-lb
+rv64ui-v-lbu
+rv64ui-v-ld
+rv64ui-v-lh
+rv64ui-v-lhu
+rv64ui-v-lui
+rv64ui-v-lw
+rv64ui-v-lwu
+rv64ui-v-or
+rv64ui-v-ori
+rv64ui-v-sb
+rv64ui-v-sd
+rv64ui-v-sh
+rv64ui-v-simple
+rv64ui-v-sll
+rv64ui-v-slli
+rv64ui-v-slliw
+rv64ui-v-sllw
+rv64ui-v-slt
+rv64ui-v-slti
+rv64ui-v-sltiu
+rv64ui-v-sltu
+rv64ui-v-sra
+rv64ui-v-srai
+rv64ui-v-sraiw
+rv64ui-v-sraw
+rv64ui-v-srl
+rv64ui-v-srli
+rv64ui-v-srliw
+rv64ui-v-srlw
+rv64ui-v-sub
+rv64ui-v-subw
+rv64ui-v-sw
+rv64ui-v-xor
+rv64ui-v-xori
+# -------------------------------------------------------------------
+# Passing zba (all RV64)
+# -------------------------------------------------------------------
+rv64uzba-p-add_uw
+rv64uzba-p-sh1add
+rv64uzba-p-sh1add_uw
+rv64uzba-p-sh2add
+rv64uzba-p-sh2add_uw
+rv64uzba-p-sh3add
+rv64uzba-p-sh3add_uw
+rv64uzba-p-slli_uw
+x rv64uzba-v-add_uw
+x rv64uzba-v-sh1add
+x rv64uzba-v-sh1add_uw
+x rv64uzba-v-sh2add
+x rv64uzba-v-sh2add_uw
+x rv64uzba-v-sh3add
+x rv64uzba-v-sh3add_uw
+x rv64uzba-v-slli_uw
+# -------------------------------------------------------------------
+# Passing zbb (all RV64)
+# -------------------------------------------------------------------
+rv64uzbb-p-andn
+rv64uzbb-p-cpop
+rv64uzbb-p-cpopw
+rv64uzbb-p-ctz
+rv64uzbb-p-ctzw
+rv64uzbb-p-max
+rv64uzbb-p-maxu
+rv64uzbb-p-min
+rv64uzbb-p-minu
+rv64uzbb-p-orn
+rv64uzbb-p-sext_b
+rv64uzbb-p-sext_h
+rv64uzbb-p-xnor
+rv64uzbb-p-zext_h
+rv64uzbb-p-clz
+rv64uzbb-p-clzw
+rv64uzbb-p-orc_b
+rv64uzbb-p-rev8
+rv64uzbb-p-rol
+rv64uzbb-p-rolw
+rv64uzbb-p-ror
+rv64uzbb-p-rori
+rv64uzbb-p-roriw
+rv64uzbb-p-rorw
+rv64uzbb-v-andn
+rv64uzbb-v-clz
+rv64uzbb-v-clzw
+rv64uzbb-v-cpop
+rv64uzbb-v-cpopw
+rv64uzbb-v-ctz
+rv64uzbb-v-ctzw
+rv64uzbb-v-max
+rv64uzbb-v-maxu
+rv64uzbb-v-min
+rv64uzbb-v-minu
+rv64uzbb-v-orc_b
+rv64uzbb-v-orn
+rv64uzbb-v-rev8
+rv64uzbb-v-rol
+rv64uzbb-v-rolw
+rv64uzbb-v-ror
+rv64uzbb-v-rori
+rv64uzbb-v-roriw
+rv64uzbb-v-rorw
+rv64uzbb-v-sext_b
+rv64uzbb-v-sext_h
+rv64uzbb-v-xnor
+rv64uzbb-v-zext_h
+
+# -------------------------------------------------------------------
+# Passing zbc (all RV64)
+# -------------------------------------------------------------------
+rv64uzbc-p-clmul
+rv64uzbc-p-clmulh
+rv64uzbc-p-clmulr
+x rv64uzbc-v-clmul
+x rv64uzbc-v-clmulh
+x rv64uzbc-v-clmulr
+# -------------------------------------------------------------------
+# Passing zbs (all RV64)
+# -------------------------------------------------------------------
+rv64uzbs-p-bclr
+rv64uzbs-p-bclri
+rv64uzbs-p-bext
+rv64uzbs-p-bexti
+rv64uzbs-p-binv
+rv64uzbs-p-binvi
+rv64uzbs-p-bset
+rv64uzbs-p-bseti
+rv64uzbs-v-bclr
+rv64uzbs-v-bclri
+rv64uzbs-v-bext
+rv64uzbs-v-bexti
+rv64uzbs-v-binv
+rv64uzbs-v-binvi
+rv64uzbs-v-bset
+rv64uzbs-v-bseti
+
+# -------------------------------------------------------------------
+# Failing zfh
+# -------------------------------------------------------------------
+x rv64uzfh-p-fadd
+x rv64uzfh-p-fclass
+x rv64uzfh-p-fcmp
+x rv64uzfh-p-fcvt
+x rv64uzfh-p-fcvt_w
+
+x rv64uzfh-p-fdiv
+x rv64uzfh-p-fmadd
+x rv64uzfh-p-fmin
+x rv64uzfh-p-ldst
+
+x rv64uzfh-p-move
+x rv64uzfh-p-recoding
+x rv64uzfh-v-fadd
+x rv64uzfh-v-fclass
+
+x rv64uzfh-v-fcmp
+x rv64uzfh-v-fcvt
+x rv64uzfh-v-fcvt_w
+x rv64uzfh-v-fdiv
+x rv64uzfh-v-fmadd
+x rv64uzfh-v-fmin
+x rv64uzfh-v-ldst
+x rv64uzfh-v-move
+x rv64uzfh-v-recoding
+
+# -------------------------------------------------------------------
+# Other Fails
+# -------------------------------------------------------------------
+x rv64mzicbo-p-zero
+x rv64ssvnapot-p-napot
+x rv64ui-p-ma_data
+x rv64ui-v-ma_data
+
+# -------------------------------------------------------------------
+# RV32 is not tested
+# -------------------------------------------------------------------
+x rv32mi-p-breakpoint
+x rv32mi-p-csr
+x rv32mi-p-illegal
+x rv32mi-p-lh-misaligned
+x rv32mi-p-lw-misaligned
+x rv32mi-p-ma_addr
+x rv32mi-p-ma_fetch
+x rv32mi-p-mcsr
+x rv32mi-p-sbreak
+x rv32mi-p-scall
+x rv32mi-p-sh-misaligned
+x rv32mi-p-shamt
+x rv32mi-p-sw-misaligned
+x rv32mi-p-zicntr
+x rv32si-p-csr
+x rv32si-p-dirty
+x rv32si-p-ma_fetch
+x rv32si-p-sbreak
+x rv32si-p-scall
+x rv32si-p-wfi
+x rv32ua-p-amoadd_w
+x rv32ua-p-amoand_w
+x rv32ua-p-amomax_w
+x rv32ua-p-amomaxu_w
+x rv32ua-p-amomin_w
+x rv32ua-p-amominu_w
+x rv32ua-p-amoor_w
+x rv32ua-p-amoswap_w
+x rv32ua-p-amoxor_w
+x rv32ua-p-lrsc
+x rv32ua-v-amoadd_w
+x rv32ua-v-amoand_w
+x rv32ua-v-amomax_w
+x rv32ua-v-amomaxu_w
+x rv32ua-v-amomin_w
+x rv32ua-v-amominu_w
+x rv32ua-v-amoor_w
+x rv32ua-v-amoswap_w
+x rv32ua-v-amoxor_w
+x rv32ua-v-lrsc
+x rv32uc-p-rvc
+x rv32uc-v-rvc
+x rv32ud-p-fadd
+x rv32ud-p-fclass
+x rv32ud-p-fcmp
+x rv32ud-p-fcvt
+x rv32ud-p-fcvt_w
+x rv32ud-p-fdiv
+x rv32ud-p-fmadd
+x rv32ud-p-fmin
+x rv32ud-p-ldst
+x rv32ud-p-recoding
+x rv32ud-v-fadd
+x rv32ud-v-fclass
+x rv32ud-v-fcmp
+x rv32ud-v-fcvt
+x rv32ud-v-fcvt_w
+x rv32ud-v-fdiv
+x rv32ud-v-fmadd
+x rv32ud-v-fmin
+x rv32ud-v-ldst
+x rv32ud-v-recoding
+x rv32uf-p-fadd
+x rv32uf-p-fclass
+x rv32uf-p-fcmp
+x rv32uf-p-fcvt
+x rv32uf-p-fcvt_w
+x rv32uf-p-fdiv
+x rv32uf-p-fmadd
+x rv32uf-p-fmin
+x rv32uf-p-ldst
+x rv32uf-p-move
+x rv32uf-p-recoding
+x rv32uf-v-fadd
+x rv32uf-v-fclass
+x rv32uf-v-fcmp
+x rv32uf-v-fcvt
+x rv32uf-v-fcvt_w
+x rv32uf-v-fdiv
+x rv32uf-v-fmadd
+x rv32uf-v-fmin
+x rv32uf-v-ldst
+x rv32uf-v-move
+x rv32uf-v-recoding
+x rv32ui-p-add
+x rv32ui-p-addi
+x rv32ui-p-and
+x rv32ui-p-andi
+x rv32ui-p-auipc
+x rv32ui-p-beq
+x rv32ui-p-bge
+x rv32ui-p-bgeu
+x rv32ui-p-blt
+x rv32ui-p-bltu
+x rv32ui-p-bne
+x rv32ui-p-fence_i
+x rv32ui-p-jal
+x rv32ui-p-jalr
+x rv32ui-p-lb
+x rv32ui-p-lbu
+x rv32ui-p-lh
+x rv32ui-p-lhu
+x rv32ui-p-lui
+x rv32ui-p-lw
+x rv32ui-p-ma_data
+x rv32ui-p-or
+x rv32ui-p-ori
+x rv32ui-p-sb
+x rv32ui-p-sh
+x rv32ui-p-simple
+x rv32ui-p-sll
+x rv32ui-p-slli
+x rv32ui-p-slt
+x rv32ui-p-slti
+x rv32ui-p-sltiu
+x rv32ui-p-sltu
+x rv32ui-p-sra
+x rv32ui-p-srai
+x rv32ui-p-srl
+x rv32ui-p-srli
+x rv32ui-p-sub
+x rv32ui-p-sw
+x rv32ui-p-xor
+x rv32ui-p-xori
+x rv32ui-v-add
+x rv32ui-v-addi
+x rv32ui-v-and
+x rv32ui-v-andi
+x rv32ui-v-auipc
+x rv32ui-v-beq
+x rv32ui-v-bge
+x rv32ui-v-bgeu
+x rv32ui-v-blt
+x rv32ui-v-bltu
+x rv32ui-v-bne
+x rv32ui-v-fence_i
+x rv32ui-v-jal
+x rv32ui-v-jalr
+x rv32ui-v-lb
+x rv32ui-v-lbu
+x rv32ui-v-lh
+x rv32ui-v-lhu
+x rv32ui-v-lui
+x rv32ui-v-lw
+x rv32ui-v-ma_data
+x rv32ui-v-or
+x rv32ui-v-ori
+x rv32ui-v-sb
+x rv32ui-v-sh
+x rv32ui-v-simple
+x rv32ui-v-sll
+x rv32ui-v-slli
+x rv32ui-v-slt
+x rv32ui-v-slti
+x rv32ui-v-sltiu
+x rv32ui-v-sltu
+x rv32ui-v-sra
+x rv32ui-v-srai
+x rv32ui-v-srl
+x rv32ui-v-srli
+x rv32ui-v-sub
+x rv32ui-v-sw
+x rv32ui-v-xor
+x rv32ui-v-xori
+x rv32um-p-div
+x rv32um-p-divu
+x rv32um-p-mul
+x rv32um-p-mulh
+x rv32um-p-mulhsu
+x rv32um-p-mulhu
+x rv32um-p-rem
+x rv32um-p-remu
+x rv32um-v-div
+x rv32um-v-divu
+x rv32um-v-mul
+x rv32um-v-mulh
+x rv32um-v-mulhsu
+x rv32um-v-mulhu
+x rv32um-v-rem
+x rv32um-v-remu
+x rv32uzba-p-sh1add
+x rv32uzba-p-sh2add
+x rv32uzba-p-sh3add
+x rv32uzba-v-sh1add
+x rv32uzba-v-sh2add
+x rv32uzba-v-sh3add
+x rv32uzbb-p-andn
+x rv32uzbb-p-clz
+x rv32uzbb-p-cpop
+x rv32uzbb-p-ctz
+x rv32uzbb-p-max
+x rv32uzbb-p-maxu
+x rv32uzbb-p-min
+x rv32uzbb-p-minu
+x rv32uzbb-p-orc_b
+x rv32uzbb-p-orn
+x rv32uzbb-p-rev8
+x rv32uzbb-p-rol
+x rv32uzbb-p-ror
+x rv32uzbb-p-rori
+x rv32uzbb-p-sext_b
+x rv32uzbb-p-sext_h
+x rv32uzbb-p-xnor
+x rv32uzbb-p-zext_h
+x rv32uzbb-v-andn
+x rv32uzbb-v-clz
+x rv32uzbb-v-cpop
+x rv32uzbb-v-ctz
+x rv32uzbb-v-max
+x rv32uzbb-v-maxu
+x rv32uzbb-v-min
+x rv32uzbb-v-minu
+x rv32uzbb-v-orc_b
+x rv32uzbb-v-orn
+x rv32uzbb-v-rev8
+x rv32uzbb-v-rol
+x rv32uzbb-v-ror
+x rv32uzbb-v-rori
+x rv32uzbb-v-sext_b
+x rv32uzbb-v-sext_h
+x rv32uzbb-v-xnor
+x rv32uzbb-v-zext_h
+x rv32uzbc-p-clmul
+x rv32uzbc-p-clmulh
+x rv32uzbc-p-clmulr
+x rv32uzbc-v-clmul
+x rv32uzbc-v-clmulh
+x rv32uzbc-v-clmulr
+x rv32uzbs-p-bclr
+x rv32uzbs-p-bclri
+x rv32uzbs-p-bext
+x rv32uzbs-p-bexti
+x rv32uzbs-p-binv
+x rv32uzbs-p-binvi
+x rv32uzbs-p-bset
+x rv32uzbs-p-bseti
+x rv32uzbs-v-bclr
+x rv32uzbs-v-bclri
+x rv32uzbs-v-bext
+x rv32uzbs-v-bexti
+x rv32uzbs-v-binv
+x rv32uzbs-v-binvi
+x rv32uzbs-v-bset
+x rv32uzbs-v-bseti
+x rv32uzfh-p-fadd
+x rv32uzfh-p-fclass
+x rv32uzfh-p-fcmp
+x rv32uzfh-p-fcvt
+x rv32uzfh-p-fcvt_w
+x rv32uzfh-p-fdiv
+x rv32uzfh-p-fmadd
+x rv32uzfh-p-fmin
+x rv32uzfh-p-ldst
+x rv32uzfh-p-move
+x rv32uzfh-p-recoding
+x rv32uzfh-v-fadd
+x rv32uzfh-v-fclass
+x rv32uzfh-v-fcmp
+x rv32uzfh-v-fcvt
+x rv32uzfh-v-fcvt_w
+x rv32uzfh-v-fdiv
+x rv32uzfh-v-fmadd
+x rv32uzfh-v-fmin
+x rv32uzfh-v-ldst
+x rv32uzfh-v-move
+x rv32uzfh-v-recoding

--- a/tests/scripts/run_riscv_isa_tests.sh
+++ b/tests/scripts/run_riscv_isa_tests.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+export RISCV_TEST_DIR=./test_binaries/share/riscv-tests/isa
+ALLOWED_TESTS_FILE=./scripts/isa_test_list.txt
+
+passed_tests=0
+failed_tests=0
+total_tests=0
+test_counter=0
+last_test_duration=0
+
+passed_tests_list=()
+
+if [ -z "$SPIKE_BINARY" ]; then
+    echo "Error: SPIKE_BINARY environment variable is not set!"
+    exit 1
+fi
+
+if [ ! -d "$RISCV_TEST_DIR" ]; then
+    echo "Error: Test directory $RISCV_TEST_DIR does not exist"
+    exit 1
+fi
+
+if [ ! -f "$ALLOWED_TESTS_FILE" ]; then
+    echo "Error: Allowed tests file $ALLOWED_TESTS_FILE does not exist"
+    exit 1
+fi
+
+mapfile -t allowed_test_files < "$ALLOWED_TESTS_FILE"
+
+trap ctrl_c_handler SIGINT
+ctrl_c_handler() {
+    echo "Stopping test execution..."
+    exit 1
+}
+
+run_test() {
+    local test_file="$1"
+    test_counter=$((test_counter + 1))
+
+    # Print "Running test test_name ..."
+    echo -n "Running test $test_file ... "
+
+    # Run the test
+    $SPIKE_BINARY "$test_file" &
+    SPIKE_PID=$!
+
+    wait $SPIKE_PID
+    EXIT_CODE=$?
+
+    # Append PASS or FAIL to the same line
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "PASS"
+        passed_tests=$((passed_tests + 1))
+        passed_tests_list+=("$test_file")
+    else
+        echo "FAIL (exit code $EXIT_CODE)"
+        failed_tests=$((failed_tests + 1))
+    fi
+}
+
+for test_file in "${allowed_test_files[@]}"; do
+    test_file=$(echo "$test_file" | xargs)
+
+    if [[ -z "$test_file" ]]; then
+        continue
+    fi
+
+    if [[ "$test_file" =~ ^# ]] || [[ "$test_file" =~ ^x ]]; then
+        continue
+    fi
+
+    full_test_path="$RISCV_TEST_DIR/$test_file"
+    total_tests=$((total_tests + 1))
+
+    if [ -f "$full_test_path" ]; then
+        run_test "$full_test_path"
+    else
+        echo "Warning: Test file $full_test_path does not exist"
+        echo "Test $test_file failed due to missing file"
+        failed_tests=$((failed_tests + 1))
+    fi
+done
+
+echo
+echo "Tests passed: $passed_tests"
+echo "Tests failed: $failed_tests"
+echo "-----"
+echo
+
+exit $failed_tests

--- a/tests/scripts/run_stf_gen_test.sh
+++ b/tests/scripts/run_stf_gen_test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+TEST_BINARIES_DIR="./test_binaries/custom-output/stf_gen"
+
+if [ -z "$SPIKE_BINARY" ]; then
+  echo "Error: SPIKE_BINARY is not set!"
+  exit 1
+fi
+
+if [ ! -d "$TEST_BINARIES_DIR" ]; then
+  echo "Error: Test binaries directory $TEST_BINARIES_DIR does not exist!"
+  exit 1
+fi
+
+total_tests=0
+passed_tests=0
+failed_tests=0
+failed_tests_list=()
+passed_tests_list=()
+
+run_test() {
+    local test_file="$1"
+    total_tests=$((total_tests + 1))
+
+    echo -n "Running test $test_file ... "
+
+    #TODO - figure out how to run this test on spike, if possible, it freezes now
+    #$SPIKE_BINARY "$test_file" &
+    SPIKE_PID=$!
+    wait $SPIKE_PID
+    #EXIT_CODE=$?
+    EXIT_CODE=1
+
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "PASS"
+        passed_tests=$((passed_tests + 1))
+        passed_tests_list+=("$test_file")
+    else
+        echo "FAIL (exit code $EXIT_CODE)"
+        failed_tests=$((failed_tests + 1))
+        failed_tests_list+=("$test_file")
+    fi
+}
+
+for binary in "$TEST_BINARIES_DIR"/*; do
+    if [ -x "$binary" ]; then
+        run_test "$binary"
+    else
+        echo "Skipping $binary (not executable)"
+    fi
+done
+
+if [ ${#failed_tests_list[@]} -gt 0 ]; then
+    echo
+    echo "Failed Tests:"
+    for failed_test in "${failed_tests_list[@]}"; do
+        echo "  $failed_test"
+    done
+fi
+
+echo
+echo "Tests passed: $passed_tests"
+echo "Tests failed: $failed_tests"
+echo "-----"
+echo
+
+exit $failed_tests


### PR DESCRIPTION
`riscv-tests` proof of concept with `cpm.riscv-isa-sim` - `make test` target builds components from `cpm.riscv-tests` submodule and runs test scripts.
 
 Important notes:
 - `cpm.riscv-tests` needs to be checkout to `siwan/cn_119_cpm_riscv_tests_submodule` branch to work
 - there are issues with running stf_gen elfs against `spike` - commented with "TODO"
 - this is proof of concept, please comment on it and let me know how to proceed further