### PR TITLE
Small fix to STF instruction count tracing

### DIFF
--- a/riscv/stf_handler.h
+++ b/riscv/stf_handler.h
@@ -79,7 +79,7 @@ struct StfHandler
   // ---------------------------------------------------------------- 
   inline void initialize_if(processor_t *p,insn_fetch_t &fetch) {
     //stf_writer will for the most part be initialized except at start
-    if((bool)stf_writer == false && _in_trace_region) [[unlikely]] {
+    if((bool)stf_writer == false && in_traceable_region()) [[unlikely]] {
       open_trace(p,fetch);
       record_machine_state(p);
     }


### PR DESCRIPTION
When we were reaching executed_instructions count for the first time we tried to record_machine_state() with stf_writer stream closed (causing an exception), as initialize_if() relied only on _in_trace_region member while at init state we're in _pending_region and then switch to _in_trace_region at this record_machine_state() call. Changed initialize_if() to rely on helper method in_traceable_region() which uses pending as well as tracing region flag.